### PR TITLE
Add simple todo creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+todo.txt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ impl Config {
         };
 
         let command = match command.as_str() {
-            "c" => Command::CreateTodo,
+            "a" => Command::CreateTodo,
+            "add" => Command::CreateTodo,
             _ => Command::Unsupported,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -13,13 +14,18 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn from_args(args: &[String]) -> Result<Config, &str> {
-        if args.len() < 3 {
-            return Err("Not enough arguments");
-        }
+    pub fn from_args(mut args: env::Args) -> Result<Config, &'static str> {
+        args.next();
 
-        let command = args[1].clone();
-        let target = args[2].clone();
+        let command = match args.next() {
+            Some(arg) => arg,
+            None => return Err("Please specify a command!"),
+        };
+
+        let target = match args.next() {
+            Some(arg) => arg,
+            None => return Err("Please specify a target!"),
+        };
 
         let command = match command.as_str() {
             "c" => Command::CreateTodo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,22 +35,21 @@ impl Config {
 
 pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
     match config.command {
-        Command::CreateTodo => create_todo(&config.target),
-        _ => (),
+        Command::CreateTodo => {
+            create_todo(&config.target)?;
+            Ok(())
+        }
+        _ => Ok(()),
     }
-
-    Ok(())
 }
 
-fn create_todo(todo: &str) {
+fn create_todo(todo: &str) -> Result<(), std::io::Error> {
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open("todo.txt")
         .unwrap();
 
-    if let Err(e) = writeln!(file, "{}", todo) {
-        eprintln!("Could not write: '{}' to file: {}", todo, "todo.txt");
-        eprintln!("{}", e);
-    }
+    writeln!(file, "{}", todo)?;
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::error::Error;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 
@@ -26,20 +25,14 @@ impl Config {
             _ => Command::Unsupported,
         };
 
-        match command {
-            Command::Unsupported => Err("Unsupported command!"),
-            _ => Ok(Config { command, target }),
-        }
+        Ok(Config { command, target })
     }
 }
 
-pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
+pub fn run(config: Config) -> Result<(), String> {
     match config.command {
-        Command::CreateTodo => {
-            create_todo(&config.target)?;
-            Ok(())
-        }
-        _ => Ok(()),
+        Command::CreateTodo => create_todo(&config.target).or_else(|err| Err(err.to_string())),
+        Command::Unsupported => Err(String::from("Unsupported command!")),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,9 @@ fn create_todo(todo: &str) -> Result<(), std::io::Error> {
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open("todo.txt")
-        .unwrap();
+        .open("todo.txt")?;
 
     writeln!(file, "{}", todo)?;
+
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,15 +17,8 @@ impl Config {
     pub fn from_args(mut args: env::Args) -> Result<Config, &'static str> {
         args.next();
 
-        let command = match args.next() {
-            Some(arg) => arg,
-            None => return Err("Please specify a command!"),
-        };
-
-        let target = match args.next() {
-            Some(arg) => arg,
-            None => return Err("Please specify a target!"),
-        };
+        let command = args.next().ok_or("Please specify a command!")?;
+        let target = args.next().ok_or("Please specify a target!")?;
 
         let command = match command.as_str() {
             "a" => Command::CreateTodo,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,56 @@
+use std::error::Error;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+
+pub enum Command {
+    CreateTodo,
+    Unsupported,
+}
+
+pub struct Config {
+    command: Command,
+    target: String,
+}
+
+impl Config {
+    pub fn from_args(args: &[String]) -> Result<Config, &str> {
+        if args.len() < 3 {
+            return Err("Not enough arguments");
+        }
+
+        let command = args[1].clone();
+        let target = args[2].clone();
+
+        let command = match command.as_str() {
+            "c" => Command::CreateTodo,
+            _ => Command::Unsupported,
+        };
+
+        match command {
+            Command::Unsupported => Err("Unsupported command!"),
+            _ => Ok(Config { command, target }),
+        }
+    }
+}
+
+pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
+    match config.command {
+        Command::CreateTodo => create_todo(&config.target),
+        _ => (),
+    }
+
+    Ok(())
+}
+
+fn create_todo(todo: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open("todo.txt")
+        .unwrap();
+
+    if let Err(e) = writeln!(file, "{}", todo) {
+        eprintln!("Could not write: '{}' to file: {}", todo, "todo.txt");
+        eprintln!("{}", e);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,7 @@ use std::process;
 use rust_todo::Config;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-
-    let config = Config::from_args(&args).unwrap_or_else(|err| {
+    let config = Config::from_args(env::args()).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {}", err);
         process::exit(1);
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,18 @@
+use std::env;
+use std::process;
+
+use rust_todo::Config;
+
 fn main() {
-    println!("Hello, world!");
+    let args: Vec<String> = env::args().collect();
+
+    let config = Config::from_args(&args).unwrap_or_else(|err| {
+        eprintln!("Problem parsing arguments: {}", err);
+        process::exit(1);
+    });
+
+    if let Err(e) = rust_todo::run(config) {
+        eprintln!("Application error: {}", e);
+        process::exit(1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,13 @@ use rust_todo::Config;
 fn main() {
     let config = Config::from_args(env::args()).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {}", err);
+
         process::exit(1);
     });
 
     if let Err(e) = rust_todo::run(config) {
         eprintln!("Application error: {}", e);
+
         process::exit(1);
     }
 }


### PR DESCRIPTION
Adds simple task creation by calling the executable with the arguments
`c "task description"`.

Handles an invalid number of arguments and different "command" arguments
than 'c'.

Appends task text as a new line directly in the current context's
`todo.txt`. If the file does not exist, it creates it before appending.